### PR TITLE
Fix version file syntax error

### DIFF
--- a/EvaFollower.version
+++ b/EvaFollower.version
@@ -16,7 +16,6 @@
     "MAJOR": 1,
     "MINOR": 8,
     "PATCH": 0
-  }
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,


### PR DESCRIPTION
The 1.1.1.9 release has a syntax error in its version file, there's an extra `}` character. Now it's fixed.

@DasSkelett has created a tool that detects errors like this before release, highly recommended:

- https://github.com/DasSkelett/AVC-VersionFileValidator